### PR TITLE
Optional request bodies

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn main() -> anyhow::Result<()> {
     let mut components = spec.components.unwrap_or_default();
 
     if let Some(paths) = spec.paths {
-        let api = Api::new(paths, with_deprecated).unwrap();
+        let api = Api::new(paths, with_deprecated, &components.schemas).unwrap();
         {
             let mut api_file = BufWriter::new(File::create("api.ron")?);
             writeln!(api_file, "{api:#?}")?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -72,7 +72,7 @@ impl FieldType {
             Some(SingleOrVec::Vec(types)) => {
                 bail!("unsupported multi-typed parameter: `{types:?}`")
             }
-            None => match get_schema_name(obj.reference) {
+            None => match get_schema_name(obj.reference.as_deref()) {
                 Some(name) => Self::SchemaRef(name),
                 None => bail!("unsupported type-less parameter"),
             },

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeSet, io, process::Command, sync::Mutex};
 
 use camino::Utf8Path;
 
-pub(crate) fn get_schema_name(maybe_ref: Option<String>) -> Option<String> {
+pub(crate) fn get_schema_name(maybe_ref: Option<&str>) -> Option<String> {
     let r = maybe_ref?;
     let schema_name = r.strip_prefix("#/components/schemas/");
     if schema_name.is_none() {

--- a/templates/svix_cli_resource.rs.jinja
+++ b/templates/svix_cli_resource.rs.jinja
@@ -86,7 +86,12 @@ pub enum {{ resource_type_name }}Commands {
             {# body parameter struct -#}
             {% if op.request_body_schema_name is defined -%}
                 {{ op.request_body_schema_name | to_snake_case }}:
-                    JsonOf<{{ op.request_body_schema_name }}>,
+                {% if op.request_body_all_optional %}
+                Option<JsonOf<{{ op.request_body_schema_name }}>>
+                {% else %}
+                JsonOf<{{ op.request_body_schema_name }}>
+                {% endif %}
+                ,
             {% endif -%}
 
             {# query parameters -#}
@@ -151,7 +156,13 @@ impl {{ resource_type_name }}Commands {
 
                             {# body parameter struct -#}
                             {% if op.request_body_schema_name is defined -%}
-                                {{ op.request_body_schema_name | to_snake_case }}.into_inner(),
+                                {{ op.request_body_schema_name | to_snake_case }}
+                                {% if op.request_body_all_optional -%}
+                                    .map(|x| x.into_inner()).unwrap_or_default()
+                                {% else -%}
+                                    .into_inner()
+                                {% endif -%}
+                                ,
                             {% endif -%}
 
                             {# query parameters -#}


### PR DESCRIPTION
The idea is to identify args for the CLI that can be omitted since the entire body is technically optional.

A problem with the current approach is the optionalness is applied uniform to all cases which includes `PATCH` requests. Ideally, we'd be treating the `PATCH` bodies as required, but there's no real harm in letting these flow through as-is.
Today, a user can happily pass an empty object as a body to any `PATCH` request. This will update the `updatedAt` timestamp but leave all other fields as-is.

The code for this is a little clumsy. We can likely optimize a bit, remove some clones. I'll leave that for someone with the appetite. I hear there is a different approach we might take anyway. Something involving passing the full component schemas to the template.

Here's the (gently modified) output from these template updates: https://github.com/svix/svix-webhooks/pull/1621