### PR TITLE
Take advantage of CLI's `JsonOf` now implementing `Default`

### DIFF
--- a/templates/svix_cli_resource.rs.jinja
+++ b/templates/svix_cli_resource.rs.jinja
@@ -158,11 +158,9 @@ impl {{ resource_type_name }}Commands {
                             {% if op.request_body_schema_name is defined -%}
                                 {{ op.request_body_schema_name | to_snake_case }}
                                 {% if op.request_body_all_optional -%}
-                                    .map(|x| x.into_inner()).unwrap_or_default()
-                                {% else -%}
-                                    .into_inner()
+                                    .unwrap_or_default()
                                 {% endif -%}
-                                ,
+                                    .into_inner(),
                             {% endif -%}
 
                             {# query parameters -#}


### PR DESCRIPTION
Previously for optional request bodies, we mapped an `Option<JsonOf<T>>` to get at the inner `T`, which we could `unwrap_or_default()` since the `T`s we care about all derived `Default`.

It turns out, all the `T`s across the board today that are wrapped with `JsonOf` implement `Default` so these callsites could be tidied up a small amount by adding this trait to `JsonOf`'s type bounds for `T`.

Ref: https://github.com/svix/svix-webhooks/pull/1621#discussion_r1905489113