### PR TITLE
python: Use `x-enum-varnames` for human readable variant names

### DIFF
--- a/templates/svix-lib-python/types/integer_enum.py.jinja
+++ b/templates/svix-lib-python/types/integer_enum.py.jinja
@@ -2,8 +2,8 @@ from enum import IntEnum
 
 
 class {{ type.name | to_upper_camel_case }}(IntEnum):
-    {% for value in type.values -%}
-    VALUE_{{ value }} = {{ value }}
+    {% for varname, value in type.variants -%}
+    {{ varname | to_upper_snake_case }} = {{ value }}
     {% endfor -%}
 
     def __str__(self) -> str:


### PR DESCRIPTION
Forgot to push this to the last PR :(