### PR TITLE
rust: Simplify fmt::Display impl for integer enums

### DIFF
--- a/templates/svix-lib-rust/types/integer_enum.rs.jinja
+++ b/templates/svix-lib-rust/types/integer_enum.rs.jinja
@@ -28,11 +28,6 @@ pub enum {{ type.name | to_upper_camel_case }} {
 
 impl fmt::Display for {{ type.name | to_upper_camel_case }} {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let value = match self {
-            {% for name, value in type.variants -%}
-                Self::{{ name | to_upper_camel_case }} => "{{ value }}",
-            {% endfor -%}
-        };
-        f.write_str(value)
+        write!(f, "{}", *self as i64)
     }
 }


### PR DESCRIPTION
Inspired by @svix-mman's idea to call into `serde_json` for this.