### PR TITLE
python: Refactor pydantic based models

### DIFF
--- a/templates/svix-lib-python/types/struct.py.jinja
+++ b/templates/svix-lib-python/types/struct.py.jinja
@@ -2,34 +2,21 @@ import typing as t
 from pydantic import Field
 from datetime import datetime
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 {% for c in referenced_components -%}
 from . {{ c | to_snake_case }} import {{ c | to_upper_camel_case }}
 {% endfor -%}
 
-class {{ type.name | to_upper_camel_case }}(SvixBaseModel):
+class {{ type.name | to_upper_camel_case }}(BaseModel):
 {%- if type.description is defined %}
     {{ type.description | to_doc_comment(style="python") | indent(4) }}
 {% endif %}
 {%- for field in type.fields %}
-    {%- if field.name != field.name | to_snake_case  %}
-        {%- if field.required %}
-            {%- set field_val -%} = Field(alias="{{ field.name }}"){%- endset %}
-        {%- else %}
-            {%- set field_val -%} = Field(default=None, alias="{{ field.name }}"){%- endset %}
-        {%- endif %}
-    {%- else %}
-        {%- if field.required %}
-            {%- set field_val = "" %}
-        {%- else %}
-            {%- set field_val = " = None" %}
-        {%- endif %}
-    {%- endif %}
     {%- if field.required %}
-    {{ field.name | to_snake_case }}: {{ field.type.to_python() }}{{ field_val }}
+    {{ field.name | to_snake_case }}: {{ field.type.to_python() }}
     {%- else %}
-    {{ field.name | to_snake_case }}: t.Optional[{{ field.type.to_python() }}]{{ field_val }}
+    {{ field.name | to_snake_case }}: t.Optional[{{ field.type.to_python() }}] = None
     {%- endif %}
     {%- if field.description is defined %}
     {{ field.description | to_doc_comment(style="python") | indent(4) }}

--- a/templates/svix-lib-python/types/struct.py.jinja
+++ b/templates/svix-lib-python/types/struct.py.jinja
@@ -13,8 +13,10 @@ class {{ type.name | to_upper_camel_case }}(BaseModel):
     {{ type.description | to_doc_comment(style="python") | indent(4) }}
 {% endif %}
 {%- for field in type.fields %}
-    {%- if field.required %}
+    {%- if field.required and not field.nullable %}
     {{ field.name | to_snake_case }}: {{ field.type.to_python() }}
+    {%- elif field.required and field.nullable %}
+    {{ field.name | to_snake_case }}: t.Optional[{{ field.type.to_python() }}]
     {%- else %}
     {{ field.name | to_snake_case }}: t.Optional[{{ field.type.to_python() }}] = None
     {%- endif %}


### PR DESCRIPTION
- Use alias_geneator instead of explicitly defining the aliases
- Correctly handle the nullable types