### PR TITLE
Don't generate api resource files if the resource has no operations

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -109,6 +109,10 @@ impl Resource {
         }
     }
 
+    pub fn has_operations(&self) -> bool {
+        !self.operations.is_empty()
+    }
+
     pub(crate) fn referenced_components(&self) -> BTreeSet<&str> {
         let mut res = BTreeSet::new();
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -107,10 +107,12 @@ impl Generator<'_> {
     ) -> anyhow::Result<()> {
         for resource in resources {
             let referenced_components = resource.referenced_components();
-            self.render_tpl(
-                Some(&resource.name),
-                context! { resource, referenced_components },
-            )?;
+            if resource.has_operations() {
+                self.render_tpl(
+                    Some(&resource.name),
+                    context! { resource, referenced_components },
+                )?;
+            }
             self.generate_api_resources_inner(resource.subresources.values())?;
         }
 


### PR DESCRIPTION
For some resources (for example op webhooks) The parent resource does not have any operations and an empty API file is generated.
