### PR TITLE
Correctly handle nullable fields

### DIFF
--- a/templates/svix-lib-go/types/struct.go.jinja
+++ b/templates/svix-lib-go/types/struct.go.jinja
@@ -14,7 +14,7 @@ type {{ type.name | to_upper_camel_case }} struct {
         {% if use_nullable -%}
             {% set f_type %}utils.Nullable[{{ f_type }}]{% endset -%}
         {% endif -%}
-        {% if not field.required and not use_nullable -%}
+        {% if (not field.required or field.nullable) and not use_nullable -%}
             {% set json_annotation = ",omitempty" -%}
             {% if not field.type.is_set() and not field.type.is_list() -%}
                 {% set f_type %}*{{ f_type }}{% endset -%}

--- a/templates/svix-lib-kotlin/types/struct.kt.jinja
+++ b/templates/svix-lib-kotlin/types/struct.kt.jinja
@@ -22,7 +22,7 @@ data class {{ type.name | to_upper_camel_case }}(
         {% set f_type %}MaybeUnset<{{ f_type }}>{% endset -%}
         {% set f_val = "= MaybeUnset.Unset" -%}
     {% endif -%}
-    {% if not field.required and not use_nullable -%}
+    {% if (not field.required or field.nullable) and not use_nullable -%}
         {% set f_type %}{{ f_type }}?{% endset -%}
         {% set f_val = "= null" -%}
     {% endif -%}


### PR DESCRIPTION
Ensure that nullable fields can be set to `null` on `ListResponse*Out` models