### PR TITLE
Revert "Don't generate api resource files if the resource has no operations"

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -102,10 +102,6 @@ impl Resource {
         }
     }
 
-    pub fn has_operations(&self) -> bool {
-        !self.operations.is_empty()
-    }
-
     pub(crate) fn referenced_components(&self) -> BTreeSet<&str> {
         let mut res = BTreeSet::new();
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -131,12 +131,10 @@ impl Generator<'_> {
     ) -> anyhow::Result<()> {
         for resource in resources {
             let referenced_components = resource.referenced_components();
-            if resource.has_operations() {
-                self.render_tpl(
-                    Some(&resource.name),
-                    context! { resource, referenced_components },
-                )?;
-            }
+            self.render_tpl(
+                Some(&resource.name),
+                context! { resource, referenced_components },
+            )?;
             self.generate_api_resources_inner(resource.subresources.values())?;
         }
 


### PR DESCRIPTION
Reverts svix/openapi-codegen#63

We want these files, we just need to update the templates to actually generate useful contents.