### PR TITLE
Postprocess extra generated file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,9 +485,9 @@ checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "minijinja"
-version = "2.5.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c37e1b517d1dcd0e51dc36c4567b9d5a29262b3ec8da6cb5d35e27a8fb529b5"
+checksum = "6e36f1329330bb1614c94b78632b9ce45dd7d761f3304a1bed07b2990a7c5097"
 dependencies = [
  "memo-map",
  "self_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ fs-err = "3.0.0"
 heck = "0.5.0"
 indexmap = "2.7.0"
 itertools = "0.14.0"
-minijinja = { version = "2.5.0", features = ["loader"] }
+minijinja = { version = "2.8.0", features = ["loader"] }
 schemars = "0.8.21"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -180,9 +180,13 @@ impl Generator<'_> {
 
         let out_file = BufWriter::new(File::create(&file_path)?);
 
-        self.tpl.render_to_write(ctx, out_file)?;
+        let state = self.tpl.render_to_write(ctx, out_file)?;
 
         if !self.flags.no_postprocess {
+            if let Some(extra_generated_file) = state.get_temp("extra_generated_file") {
+                self.postprocessor
+                    .add_path(Utf8Path::new(extra_generated_file.as_str().unwrap()));
+            }
             self.postprocessor.add_path(&file_path);
         }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -6,7 +6,7 @@ use heck::{
     ToLowerCamelCase as _, ToShoutySnakeCase as _, ToSnakeCase as _, ToUpperCamelCase as _,
 };
 use itertools::Itertools as _;
-use minijinja::{path_loader, value::Kwargs, Value};
+use minijinja::{path_loader, value::Kwargs, State, Value};
 
 pub(crate) fn env(tpl_dir: &Utf8Path) -> Result<minijinja::Environment<'static>, minijinja::Error> {
     let mut env = minijinja::Environment::new();
@@ -146,8 +146,9 @@ pub(crate) fn env(tpl_dir: &Utf8Path) -> Result<minijinja::Environment<'static>,
     env.add_function(
         // For java lib we need to create extra files.
         "generate_extra_file",
-        |filename: Cow<'_, str>, file_contents: Cow<'_, str>| {
+        |state: &State, filename: Cow<'_, str>, file_contents: Cow<'_, str>| {
             fs::write(&*filename, file_contents.as_bytes()).unwrap();
+            state.set_temp("extra_generated_file", filename.into());
         },
     );
 


### PR DESCRIPTION
get_temp was introduced in version 2.8.0

Limited to 1 extra file per generated component type, but I am happy with that
The extra file is a hack, I don't care about making it more robust 