### PR TITLE
Add new option `--specified-operations`

### DIFF
--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -154,7 +154,7 @@ fn execute_command(
             bail!("`{command}` failed with exit code {:?}", exit_status.code());
         }
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
-            bail!("`{command}` not found - run with --no-postprocessing to skip");
+            bail!("`{command}` not found - run with --no-postprocess to skip");
         }
         Err(e) => Err(e.into()),
     }


### PR DESCRIPTION
Allows me to only include operations from a specified list of operations, This will be helpful when I generate the internal JS lib