### PR TITLE
Enable caching on build steps

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -54,7 +54,7 @@ jobs:
           build-args: ${{ matrix.platform.build-args }}
           file: Dockerfile
           cache-from: type=gha
-          cache-to: type=gha
+          cache-to: type=gha,mode=max
           platforms: linux/${{ matrix.platform.name }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 


### PR DESCRIPTION
Need to set `mode=max` to cache the intermediate build steps. And since we are building a bunch of stuff from source (rubyfmt) caching intermediate steps is important 
https://docs.docker.com/build/cache/backends/#cache-mode