### PR TITLE
Update the biome version

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -21,8 +21,8 @@ jobs:
             build-args: |
               DOTNET_PLATFORM=linux-musl-amd64
               RUST_TARGET=x86_64-unknown-linux-musl
-              BIOME_DL_LINK=https://github.com/biomejs/biome/releases/download/cli/v1.9.4/biome-linux-x64-musl
-              BIOME_SHA256=02ca13dcbb5d78839e743b315b03c8c8832fa8178bb81c5e29ae5ad45ce96b82
+              BIOME_DL_LINK=https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%402.1.4/biome-linux-x64-musl
+              BIOME_SHA256=6d6bd2213cffab0d68d741c0be466bcd21cd6f5eca1e0e5aac2a991bf9f17cf2
               RUBYFMT_DL_LINK=https://github.com/fables-tales/rubyfmt/releases/download/v0.11.67-0/rubyfmt-v0.11.67-0-Linux-x86_64.tar.gz
               RUBYFMT_SHA256=40f734a83edcc5f03f789606293af9ea622ea2a4fc3091c551b7c1f817087dcd
           - runner: ubuntu-24.04-arm
@@ -30,8 +30,8 @@ jobs:
             build-args: |
               DOTNET_PLATFORM=linux-musl-arm64
               RUST_TARGET=aarch64-unknown-linux-musl
-              BIOME_DL_LINK=https://github.com/biomejs/biome/releases/download/cli/v1.9.4/biome-linux-arm64-musl
-              BIOME_SHA256=d34937f7b5a6f816af289e972bfd49827921ed43f44547f78180f3e4f539cc41
+              BIOME_DL_LINK=https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%402.1.4/biome-linux-arm64-musl
+              BIOME_SHA256=ffa05ea6ec0e73072e46301a692eb9413d5b683366e86ab7243414ae944f4ec4
               RUBYFMT_DL_LINK=https://github.com/fables-tales/rubyfmt/releases/download/v0.11.67-0/rubyfmt-v0.11.67-0-Linux-aarch64.tar.gz
               RUBYFMT_SHA256=805fec1bf5400513058d8ec2d5cde0b497182b80828957ef0239190aa1f01092
     name: Build and publish ${{ matrix.platform.name }} docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,8 +89,8 @@ RUN echo "25157797a0a972c2290b5bc71530c4f7ad646458025e3484412a6e5a9b8c9aa6 googl
 
 
 # Javascript
-ARG BIOME_DL_LINK="https://github.com/biomejs/biome/releases/download/cli/v1.9.4/biome-linux-x64-musl"
-ARG BIOME_SHA256="02ca13dcbb5d78839e743b315b03c8c8832fa8178bb81c5e29ae5ad45ce96b82"
+ARG BIOME_DL_LINK="https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%402.1.4/biome-linux-x64-musl"
+ARG BIOME_SHA256="6d6bd2213cffab0d68d741c0be466bcd21cd6f5eca1e0e5aac2a991bf9f17cf2"
 RUN echo "${BIOME_SHA256} biome" > biome.sha256 && \
     curl -fsSL --output biome "${BIOME_DL_LINK}" && \
     sha256sum biome.sha256 -c && \

--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -123,15 +123,11 @@ impl PostprocessorLanguage {
             Self::TypeScript => &[
                 (
                     "biome",
-                    &["lint", "--only=correctness/noUnusedImports", "--write"],
-                ),
-                (
-                    "biome",
                     &[
-                        "check",
-                        "--formatter-enabled=false",
-                        "--linter-enabled=false",
-                        "--organize-imports-enabled=true",
+                        "lint",
+                        "--only=organizeImports",
+                        "--only=noUnusedImports",
+                        "--unsafe",
                         "--write",
                     ],
                 ),


### PR DESCRIPTION
Old version deletes the `this file is @generated` comment when a bunch of extra imports were removed.

Only affected one file `javascript/src/api/operationalWebhook.ts`

Updating the version, and adding a extra newline seems to fix the issue (and the newline did not fix the issue on the current version)