### PR TITLE
Automatically prefix type only imports with `type`

### DIFF
--- a/src/postprocessing.rs
+++ b/src/postprocessing.rs
@@ -134,6 +134,7 @@ impl PostprocessorLanguage {
                         "lint",
                         "--only=organizeImports",
                         "--only=noUnusedImports",
+                        "--only=useImportType",
                         "--unsafe",
                         "--write",
                     ],


### PR DESCRIPTION
this new option will take

`import { MessageIn } from "../models/index";`
and convert it to

`import type { MessageIn } from "../models/index";`

(only if it's only used as a type)

please see this commit for the resulting codegen diff: [svix/svix-webhooks@`04bb697` (#2072)](https://github.com/svix/svix-webhooks/pull/2072/commits/04bb69753c65be885df59c14a98390e089ca0949)