### PR TITLE
Add clippy to rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
           # only save the cache on the main branch


### PR DESCRIPTION
CI failed with this error `error: 'cargo-clippy' is not installed for the toolchain 'stable-x86_64-unknown-linux-gnu'.`

https://github.com/svix/openapi-codegen/actions/runs/18017493811/job/51266096736?pr=128