### PR TITLE
Add function to allow overriding the summary filename

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -177,6 +177,14 @@ pub(crate) fn env(tpl_dir: &Utf8Path) -> Result<minijinja::Environment<'static>,
     );
 
     env.add_function(
+        // allows overriding the summary filename
+        "set_summary_filename",
+        |state: &State, filename: Cow<'_, str>| {
+            state.set_temp("summary_filename", filename.into());
+        },
+    );
+
+    env.add_function(
         // For java lib we need to create extra files.
         "generate_extra_file",
         |state: &State, filename: Cow<'_, str>, file_contents: Cow<'_, str>| {


### PR DESCRIPTION
We currently use a hardcoded list of summary (`index.ts`/`__init__.py`/`mod.rs`) filenames.

https://github.com/svix/openapi-codegen/blob/a7c7abad9d73eed6eedc68a2e07c9862042e2072/src/generator.rs#L173


This allows us to add this section to a template
```
{% do set_summary_filename("agentic_commerce_protocol.rb") %}
```

And the filename will be set to `agentic_commerce_protocol.rb`