### PR TITLE
Don't include subresources for referenced_components

### DIFF
--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Deref,
+};
 
 use aide::openapi::{self, ReferenceOr};
 use anyhow::{Context as _, bail};
@@ -119,6 +122,19 @@ impl Resource {
         }
 
         res
+    }
+
+    pub(crate) fn referenced_components_direct(&self) -> impl Iterator<Item = &str> {
+        self.operations.iter().flat_map(|op| {
+            op.query_params
+                .iter()
+                .filter_map(|qp| match &qp.r#type {
+                    FieldType::SchemaRef { name, inner: None } => Some(name.as_str()),
+                    _ => None,
+                })
+                .chain(op.request_body_schema_name.iter().map(Deref::deref))
+                .chain(op.response_body_schema_name.iter().map(Deref::deref))
+        })
     }
 }
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{collections::BTreeSet, str::FromStr};
 
 use anyhow::{Context as _, bail};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -101,7 +101,8 @@ impl Generator<'_> {
     ) -> anyhow::Result<Vec<Utf8PathBuf>> {
         let mut generated_paths = vec![];
         for resource in resources {
-            let referenced_components = resource.referenced_components();
+            let referenced_components: BTreeSet<_> =
+                resource.referenced_components_direct().collect();
             for operation in &resource.operations {
                 if operation.has_query_or_header_params() {
                     generated_paths.extend_from_slice(&self.render_tpl(
@@ -130,7 +131,8 @@ impl Generator<'_> {
         let mut generated_paths = vec![];
 
         for resource in resources {
-            let referenced_components = resource.referenced_components();
+            let referenced_components: BTreeSet<_> =
+                resource.referenced_components_direct().collect();
             generated_paths.extend_from_slice(&self.render_tpl(
                 Some(&resource.name),
                 context! { resource, referenced_components },


### PR DESCRIPTION
There is no reason to include them, at least for our codegen templates. We always put subresources in separate files.