### PR TITLE
Expose api object and schema helpers to api_resource templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "memo-map",
  "self_cell",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ fs-err = "3.0.0"
 heck = "0.5.0"
 indexmap = "2.7.0"
 itertools = "0.14.0"
-minijinja = { version = "2.8.0", features = ["loader"] }
+minijinja = { version = "2.8.0", features = ["json", "loader"] }
 ron = "0.10.1"
 schemars = "0.8.21"
 serde = { version = "1.0.215", features = ["derive", "rc"] }

--- a/src/api/struct_enum.rs
+++ b/src/api/struct_enum.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use anyhow::{Context as _, bail, ensure};
 use schemars::schema::{ObjectValidation, Schema, SchemaObject};
 
@@ -85,7 +87,7 @@ fn get_content(variant: &ObjectValidation) -> anyhow::Result<(String, EnumVarian
     for (p_name, p) in &variant.properties {
         let schema_obj = get_schema_obj(p)?;
         if let Some(obj) = &schema_obj.object {
-            let ty = TypeData::from_object_schema(*obj.clone(), None)?;
+            let ty = TypeData::from_object_schema(*obj.clone(), BTreeMap::new(), None)?;
             let TypeData::Struct { fields } = ty else {
                 bail!("Expected obj to be a struct");
             };

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -421,6 +421,9 @@ pub enum FieldType {
         inner: Option<Type>,
     },
 
+    UnixTimestampMs,
+    DurationMs,
+
     /// A string constant, used as an enum discriminator value.
     StringConst {
         value: String,
@@ -455,7 +458,12 @@ impl FieldType {
                     // FIXME: Why do we have int in the spec?
                     Some("int" | "int64") => Self::Int64,
                     // FIXME: Get rid of uint in the spec..
-                    Some("uint" | "uint64") => Self::UInt64,
+                    Some("uint" | "uint64") => match obj.extensions.get("x-subtype") {
+                        Some(s) if s == "DurationMs" => Self::DurationMs,
+                        Some(s) if s == "UnixTimestampMs" => Self::UnixTimestampMs,
+                        Some(s) => bail!("Unknown subtype {s}"),
+                        None => Self::UInt64,
+                    },
                     f => bail!("unsupported integer format: `{f:?}`"),
                 },
                 InstanceType::String => {
@@ -572,6 +580,7 @@ impl FieldType {
             }
             Self::SchemaRef { name, .. } => filter_schema_ref(name, "Object"),
             Self::StringConst { .. } => "string".into(),
+            Self::UnixTimestampMs | Self::DurationMs => "ulong".into(),
         }
     }
 
@@ -593,6 +602,7 @@ impl FieldType {
             }
             Self::SchemaRef { name, .. } => filter_schema_ref(name, "map[string]any"),
             Self::StringConst { .. } => "string".into(),
+            Self::UnixTimestampMs | Self::DurationMs => "uint64".into(),
         }
     }
 
@@ -615,6 +625,7 @@ impl FieldType {
             Self::Set { inner } => format!("Set<{}>", inner.to_kotlin_typename()).into(),
             Self::SchemaRef { name, .. } => filter_schema_ref(name, "Map<String,Any>"),
             Self::StringConst { .. } => "String".into(),
+            Self::UnixTimestampMs | Self::DurationMs => "ULong".into(),
         }
     }
 
@@ -638,6 +649,7 @@ impl FieldType {
             }
             Self::SchemaRef { name, .. } => filter_schema_ref(name, "any"),
             Self::StringConst { .. } => "string".into(),
+            Self::UnixTimestampMs | Self::DurationMs => "number".into(),
         }
     }
 
@@ -665,7 +677,8 @@ impl FieldType {
             )
             .into(),
             Self::SchemaRef { name, .. } => filter_schema_ref(name, "serde_json::Value"),
-            Self::StringConst { .. } => "String".into()
+            Self::StringConst { .. } => "String".into(),
+            Self::UnixTimestampMs | Self::DurationMs => "u64".into(),
         }
     }
 
@@ -705,6 +718,7 @@ impl FieldType {
                 format!("t.Dict[str, {}]", value_ty.to_python_typename()).into()
             }
             Self::StringConst { .. } => "str".into(),
+            Self::UnixTimestampMs | Self::DurationMs => "int".into(),
         }
     }
 
@@ -729,6 +743,7 @@ impl FieldType {
             FieldType::SchemaRef { name, .. } => filter_schema_ref(name, "Object"),
             // backwards compat
             FieldType::StringConst { .. } => "TypeEnum".into(),
+            FieldType::UnixTimestampMs | FieldType::DurationMs => "Long".into(),
         }
     }
 
@@ -757,7 +772,9 @@ impl FieldType {
             | FieldType::Uri
             | FieldType::JsonObject
             | FieldType::StringConst { .. }
-            | FieldType::SchemaRef { .. } => self.to_php_typename(),
+            | FieldType::SchemaRef { .. }
+            | FieldType::UnixTimestampMs
+            | FieldType::DurationMs => self.to_php_typename(),
             FieldType::Set { inner } | FieldType::List { inner } => {
                 format!("list<{}>", inner.to_phpdoc_typename()).into()
             }
@@ -784,6 +801,7 @@ impl FieldType {
             | FieldType::Set { .. }
             | FieldType::Map { .. } => "array".into(),
             FieldType::SchemaRef { name, .. } => name.clone().into(),
+            FieldType::UnixTimestampMs | FieldType::DurationMs => "int".into(),
         }
     }
 }
@@ -873,6 +891,14 @@ impl minijinja::value::Object for FieldType {
                 ensure_no_args(args, "is_bool")?;
                 Ok(matches!(**self, Self::Bool).into())
             }
+            "is_unix_timestamp_ms" => {
+                ensure_no_args(args, "is_unix_timestamp_ms")?;
+                Ok(matches!(**self, Self::UnixTimestampMs).into())
+            }
+            "is_duration_ms" => {
+                ensure_no_args(args, "is_duration_ms")?;
+                Ok(matches!(**self, Self::DurationMs).into())
+            }
             "is_u64" => {
                 ensure_no_args(args, "is_u64")?;
                 Ok(matches!(**self, Self::UInt64).into())
@@ -896,7 +922,9 @@ impl minijinja::value::Object for FieldType {
                     | FieldType::Set { .. }
                     | FieldType::Map { .. }
                     | FieldType::SchemaRef { .. }
-                    | FieldType::StringConst { .. } => false,
+                    | FieldType::StringConst { .. }
+                    | FieldType::UnixTimestampMs
+                    | FieldType::DurationMs => false,
                 };
                 Ok(is_int_or_uint.into())
             }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -322,6 +322,7 @@ pub struct Field {
     required: bool,
     nullable: bool,
     deprecated: bool,
+    #[serde(default)]
     positional: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     example: Option<serde_json::Value>,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -873,6 +873,10 @@ impl minijinja::value::Object for FieldType {
                 ensure_no_args(args, "is_bool")?;
                 Ok(matches!(**self, Self::Bool).into())
             }
+            "is_u64" => {
+                ensure_no_args(args, "is_u64")?;
+                Ok(matches!(**self, Self::UInt64).into())
+            }
             "is_int_or_uint" => {
                 ensure_no_args(args, "is_int_or_uint")?;
                 let is_int_or_uint = match &**self {

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -96,7 +96,7 @@ impl Type {
             Some(SingleOrVec::Single(it)) => match *it {
                 InstanceType::Object => {
                     let obj = s.object.unwrap_or_default();
-                    TypeData::from_object_schema(*obj, s.subschemas)?
+                    TypeData::from_object_schema(*obj, s.extensions, s.subschemas)?
                 }
                 InstanceType::Integer => {
                     let enum_varnames = s
@@ -188,6 +188,7 @@ pub enum TypeData {
 impl TypeData {
     pub(super) fn from_object_schema(
         obj: ObjectValidation,
+        extensions: BTreeMap<String, serde_json::Value>,
         subschemas: Option<Box<SubschemaValidation>>,
     ) -> anyhow::Result<Self> {
         ensure!(
@@ -202,11 +203,17 @@ impl TypeData {
         );
         ensure!(obj.property_names.is_none(), "unsupported: propertyNames");
 
+        let x_positional = extensions
+            .get("x-positional")
+            .and_then(|ext| Some(ext.as_array()?.as_slice()))
+            .unwrap_or(&[]);
         let fields: Vec<_> = obj
             .properties
             .into_iter()
             .map(|(name, schema)| {
-                Field::from_schema(name.clone(), schema, obj.required.contains(&name))
+                let required = obj.required.contains(&name);
+                let positional = x_positional.iter().any(|p| *p == name);
+                Field::from_schema(name.clone(), schema, required, positional)
                     .with_context(|| format!("unsupported field `{name}`"))
             })
             .collect::<anyhow::Result<_>>()?;
@@ -315,12 +322,18 @@ pub struct Field {
     required: bool,
     nullable: bool,
     deprecated: bool,
+    positional: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     example: Option<serde_json::Value>,
 }
 
 impl Field {
-    fn from_schema(name: String, s: Schema, required: bool) -> anyhow::Result<Self> {
+    fn from_schema(
+        name: String,
+        s: Schema,
+        required: bool,
+        positional: bool,
+    ) -> anyhow::Result<Self> {
         let obj = match s {
             Schema::Bool(_) => bail!("unsupported bool schema"),
             Schema::Object(o) => o,
@@ -340,6 +353,7 @@ impl Field {
             description: metadata.description,
             required,
             nullable,
+            positional,
             deprecated: metadata.deprecated,
             example,
         })

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -121,12 +121,13 @@ impl Generator<'_> {
     }
 
     fn generate_api_resources(self, api: &Api) -> anyhow::Result<Vec<Utf8PathBuf>> {
-        self.generate_api_resources_inner(api.resources.values())
+        self.generate_api_resources_inner(api.resources.values(), api)
     }
 
     fn generate_api_resources_inner<'a>(
         &self,
         resources: impl Iterator<Item = &'a Resource>,
+        api: &Api,
     ) -> anyhow::Result<Vec<Utf8PathBuf>> {
         let mut generated_paths = vec![];
 
@@ -135,10 +136,10 @@ impl Generator<'_> {
                 resource.referenced_components_direct().collect();
             generated_paths.extend_from_slice(&self.render_tpl(
                 Some(&resource.name),
-                context! { resource, referenced_components },
+                context! { api, resource, referenced_components },
             )?);
             generated_paths.extend_from_slice(
-                &self.generate_api_resources_inner(resource.subresources.values())?,
+                &self.generate_api_resources_inner(resource.subresources.values(), api)?,
             );
         }
 


### PR DESCRIPTION
This PR cherry-picks some commits from `jplatte/coyote` that are useful to improve CLI --help examples

List of commits:

- `a3d4b9f` Pass full api object to api_resource templates
- `2eb6bf8` Add preliminary support for positional parameters
- `06d1cfb` Add `FieldType::is_u64`
- `3c75d2c` Add `TimestampMs` and `DurationMs` as API types (#152)
