### PR TITLE
Update Go docker image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN dotnet publish --framework net9.0 -o output \
     /p:PublishSingleFile=true Src/CSharpier.Cli
 
 # build goimports
-FROM docker.io/golang:1.24-alpine AS goimports-builder
+FROM docker.io/golang:1.25-alpine AS goimports-builder
 
 RUN go install golang.org/x/tools/cmd/goimports@latest
 


### PR DESCRIPTION
CI is failing because of the following error:
```
 > [goimports-builder 2/5] RUN go install golang.org/x/tools/cmd/goimports@latest:
0.379 go: downloading golang.org/x/tools v0.44.0
1.073 go: golang.org/x/tools/cmd/goimports@latest: golang.org/x/tools@v0.44.0 requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```