### PR TITLE
Allow including specified ops in public mode

### DIFF
--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -196,12 +196,12 @@ impl Operation {
             .extensions
             .get("x-internal")
             .is_some_and(|val| val == true);
+        let is_specified = specified_operations.contains(&op_id);
         let include_operation = match include_mode {
-            IncludeMode::OnlyPublic => !x_internal,
+            IncludeMode::Public => !x_internal || is_specified,
             IncludeMode::PublicAndInternal => true,
-            IncludeMode::OnlyInternal => x_internal,
-            IncludeMode::OnlySpecified => specified_operations.contains(&op_id),
-            IncludeMode::PublicAndSpecified => !x_internal || specified_operations.contains(&op_id),
+            IncludeMode::Internal => x_internal || is_specified,
+            IncludeMode::OnlySpecified => is_specified,
         };
         if !include_operation || excluded_operations.contains(&op_id) {
             return None;

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -201,6 +201,7 @@ impl Operation {
             IncludeMode::PublicAndInternal => true,
             IncludeMode::OnlyInternal => x_internal,
             IncludeMode::OnlySpecified => specified_operations.contains(&op_id),
+            IncludeMode::PublicAndSpecified => !x_internal || specified_operations.contains(&op_id),
         };
         if !include_operation || excluded_operations.contains(&op_id) {
             return None;

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -31,10 +31,9 @@ pub(crate) fn from_referenced_components(
     include_mode: IncludeMode,
 ) -> Types {
     let mut referenced_components: Vec<&str> = match include_mode {
-        IncludeMode::OnlyPublic
-        | IncludeMode::PublicAndInternal
-        | IncludeMode::OnlyInternal
-        | IncludeMode::PublicAndSpecified => webhooks.iter().map(|s| &**s).collect(),
+        IncludeMode::Public | IncludeMode::PublicAndInternal | IncludeMode::Internal => {
+            webhooks.iter().map(|s| &**s).collect()
+        }
         IncludeMode::OnlySpecified => vec![],
     };
     referenced_components.extend(resources::referenced_components(res));

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -31,9 +31,10 @@ pub(crate) fn from_referenced_components(
     include_mode: IncludeMode,
 ) -> Types {
     let mut referenced_components: Vec<&str> = match include_mode {
-        IncludeMode::OnlyPublic | IncludeMode::PublicAndInternal | IncludeMode::OnlyInternal => {
-            webhooks.iter().map(|s| &**s).collect()
-        }
+        IncludeMode::OnlyPublic
+        | IncludeMode::PublicAndInternal
+        | IncludeMode::OnlyInternal
+        | IncludeMode::PublicAndSpecified => webhooks.iter().map(|s| &**s).collect(),
         IncludeMode::OnlySpecified => vec![],
     };
     referenced_components.extend(resources::referenced_components(res));

--- a/src/cli_v1.rs
+++ b/src/cli_v1.rs
@@ -35,7 +35,7 @@ struct CliArgs {
 
     /// Only include specified operations
     ///
-    /// This option only works with `--include-mode=only-specified`.
+    /// This option only works with `--include-mode=only-specified` or `--include-mode=public-and-specified`.
     ///
     /// Use this option, to run the codegen with a limited set of operations.
     /// Op webhook models will be excluded from the generation
@@ -85,6 +85,8 @@ pub enum IncludeMode {
     OnlyInternal,
     /// Only operations that were specified in `--include-op-id`
     OnlySpecified,
+    /// Both public operations and operations specified in `--include-op-id`
+    PublicAndSpecified,
 }
 
 pub fn run_cli_v1_main() -> anyhow::Result<()> {

--- a/src/cli_v1.rs
+++ b/src/cli_v1.rs
@@ -26,16 +26,14 @@ use crate::{api::Api, generator::generate};
 #[derive(Parser)]
 struct CliArgs {
     /// Which operations to include.
-    #[arg(global = true, long, value_enum, default_value_t = IncludeMode::OnlyPublic)]
+    #[arg(global = true, long, value_enum, default_value_t = IncludeMode::Public)]
     include_mode: IncludeMode,
 
     /// Ignore a specified operation id
     #[arg(global = true, short, long = "exclude-op-id")]
     excluded_operations: Vec<String>,
 
-    /// Only include specified operations
-    ///
-    /// This option only works with `--include-mode=only-specified` or `--include-mode=public-and-specified`.
+    /// Include specified operations
     ///
     /// Use this option, to run the codegen with a limited set of operations.
     /// Op webhook models will be excluded from the generation
@@ -77,16 +75,14 @@ enum Command {
 #[derive(Copy, Clone, clap::ValueEnum)]
 #[clap(rename_all = "kebab-case")]
 pub enum IncludeMode {
-    /// Only public options
-    OnlyPublic,
+    /// Public operations and operations specified in `--include-op-id`
+    Public,
     /// Both public operations and operations marked with `x-internal`
     PublicAndInternal,
-    /// Only operations marked with `x-internal`
-    OnlyInternal,
+    /// Only operations marked with `x-internal` and operations specified in `--include-op-id`
+    Internal,
     /// Only operations that were specified in `--include-op-id`
     OnlySpecified,
-    /// Both public operations and operations specified in `--include-op-id`
-    PublicAndSpecified,
 }
 
 pub fn run_cli_v1_main() -> anyhow::Result<()> {

--- a/src/codesamples.rs
+++ b/src/codesamples.rs
@@ -203,7 +203,7 @@ pub async fn generate_codesamples(
             .context("found no endpoints in input spec")?,
         &mut openapi_spec.components.clone().unwrap_or_default(),
         &[],
-        IncludeMode::OnlyPublic,
+        IncludeMode::Public,
         &excluded_operation_ids,
         &BTreeSet::new(),
     )?;


### PR DESCRIPTION
The `include-op-id` option shouldn't be ignored when using `Public` or `Internal` include modes. This also renames the include mode to reflect this behavior