### PR TITLE
Make full API available to codesamples generation

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -295,7 +295,7 @@ impl TypeData {
                                 .as_str()
                                 .context(format!(
                                     "enum varname {} is not a string",
-                                    &enum_varnames[i]
+                                    enum_varnames[i]
                                 ))?
                                 .to_string(),
                             num,

--- a/src/codesamples.rs
+++ b/src/codesamples.rs
@@ -118,7 +118,7 @@ fn generate_sample(
                 .request_body_schema_name
                 .as_ref()
                 .map(|req_body_name| recursively_resolve_type(req_body_name, api));
-            let ctx = context! { operation, resource_parents, req_body_ty };
+            let ctx = context! { api, operation, resource_parents, req_body_ty };
 
             let codesample = env.render_str(&source, ctx).unwrap();
             let sample = CodeSample {


### PR DESCRIPTION
Small thing for the diom branch that we don't _need_ in webhooks, but doesn't hurt either.