### PR TITLE
Enable preserve_order in schemars, serde_json by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 
+[features]
+default = ["preserve_order"]
+preserve_order = ["schemars/preserve_order", "serde_json/preserve_order"]
+
 [dependencies]
 aide = "=0.16.0-alpha.4"
 anyhow = "1.0.94"


### PR DESCRIPTION
Part of https://github.com/svix/monorepo-private/issues/13492.