### PR TITLE
openapi-codegen: improve build and CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    # don't actually post regular version upgrade PRs, only security updates
+    open-pull-requests-limit: 0
+    # shouldn't actually matter because security update PRs happen immediately
+    # as advisories are reported, but is a required key
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # allow doing version updates for github-actions dependabot bumps
+    open-pull-requests-limit: 2
+    cooldown:
+      default-days: 3
+    groups:
+      workflows:
+        applies-to: version-updates
+        patterns:
+          - '*'
+    schedule:
+      interval: "weekly"
+      day: "wednesday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,34 +1,30 @@
 name: CI
-
 on:
   workflow_dispatch:
   push:
     branches: [main]
   pull_request:
-
 env:
   CARGO_TERM_COLOR: always
-
 jobs:
   formatting:
     name: Formatting
     runs-on: ubuntu-24.04
-
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
+          toolchain: stable
           components: rustfmt
       - run: cargo fmt --check
-
   clippy:
     name: Clippy
     runs-on: ubuntu-24.04
-
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
+          toolchain: stable
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
@@ -36,11 +32,10 @@ jobs:
           # https://github.com/Swatinem/rust-cache/issues/95
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo clippy -- -D warnings
-
-  typos:
-    name: Typos
+  prek:
+    name: Validate prek
     runs-on: ubuntu-24.04
-
     steps:
-      - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.29.3
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d # v2.0.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,14 @@
 name: CI
+
 on:
   workflow_dispatch:
   push:
     branches: [main]
   pull_request:
+
 env:
   CARGO_TERM_COLOR: always
+
 jobs:
   formatting:
     name: Formatting
@@ -17,6 +20,7 @@ jobs:
           toolchain: stable
           components: rustfmt
       - run: cargo fmt --check
+
   clippy:
     name: Clippy
     runs-on: ubuntu-24.04
@@ -32,6 +36,7 @@ jobs:
           # https://github.com/Swatinem/rust-cache/issues/95
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo clippy -- -D warnings
+
   prek:
     name: Validate prek
     runs-on: ubuntu-24.04

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,11 +1,14 @@
 name: Build and push docker image
+
 on:
   workflow_dispatch:
   push:
     branches: [main]
   pull_request:
+
 env:
   CARGO_TERM_COLOR: always
+
 jobs:
   get-version:
     runs-on: ubuntu-24.04
@@ -17,6 +20,7 @@ jobs:
           fetch-depth: 0
       - id: make_version
         run: echo "version=$(date --utc +%Y%m%d)-$(git rev-list ${{ github.sha }} --count)" >> "$GITHUB_OUTPUT"
+
   build:
     uses: docker/github-builder/.github/workflows/build.yml@v1
     needs: [get-version]

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -3,129 +3,45 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-
+  pull_request:
 env:
   CARGO_TERM_COLOR: always
-  REGISTRY_IMAGE: ghcr.io/svix/openapi-codegen
-
 jobs:
-  build:
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      matrix:
-        platform:
-          - runner: ubuntu-24.04
-            name: amd64
-            build-args: |
-              DOTNET_PLATFORM=linux-musl-amd64
-              RUST_TARGET=x86_64-unknown-linux-musl
-              BIOME_DL_LINK=https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%402.1.4/biome-linux-x64-musl
-              BIOME_SHA256=6d6bd2213cffab0d68d741c0be466bcd21cd6f5eca1e0e5aac2a991bf9f17cf2
-              RUBYFMT_DL_LINK=https://github.com/fables-tales/rubyfmt/releases/download/v0.11.67-0/rubyfmt-v0.11.67-0-Linux-x86_64.tar.gz
-              RUBYFMT_SHA256=40f734a83edcc5f03f789606293af9ea622ea2a4fc3091c551b7c1f817087dcd
-              JAVAFMT_DL_LINK=https://repo1.maven.org/maven2/com/palantir/javaformat/palantir-java-format-native/2.75.0/palantir-java-format-native-2.75.0-nativeImage-linux-glibc_x86-64.bin
-              JAVAFMT_SHA256=9d8c9e65cff44bb847d16b4db2ccbd6dacbe32611eaf2587748013eda931cdac
-          - runner: ubuntu-24.04-arm
-            name: arm64
-            build-args: |
-              DOTNET_PLATFORM=linux-musl-arm64
-              RUST_TARGET=aarch64-unknown-linux-musl
-              BIOME_DL_LINK=https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%402.1.4/biome-linux-arm64-musl
-              BIOME_SHA256=ffa05ea6ec0e73072e46301a692eb9413d5b683366e86ab7243414ae944f4ec4
-              RUBYFMT_DL_LINK=https://github.com/fables-tales/rubyfmt/releases/download/v0.11.67-0/rubyfmt-v0.11.67-0-Linux-aarch64.tar.gz
-              RUBYFMT_SHA256=805fec1bf5400513058d8ec2d5cde0b497182b80828957ef0239190aa1f01092
-              JAVAFMT_DL_LINK=https://repo1.maven.org/maven2/com/palantir/javaformat/palantir-java-format-native/2.75.0/palantir-java-format-native-2.75.0-nativeImage-linux-glibc_aarch64.bin
-              JAVAFMT_SHA256=371e226632a5c455f017fe2ce2a614abe8cf81c743b4c27fb998373b790c2a3b
-    name: Build and publish ${{ matrix.platform.name }} docker image
-    if: github.ref == 'refs/heads/main'
-    runs-on: "${{ matrix.platform.runner }}"
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Login to ghcr
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          tags: ${{ env.REGISTRY_IMAGE }}
-          build-args: ${{ matrix.platform.build-args }}
-          file: Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/${{ matrix.platform.name }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        # we create empty files with the sha256 digest of the docker image as the filename
-        # since we did not push with a tag, the only way to identify the image is with the digest
-        run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ matrix.platform.name }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  publish-merged-manifest:
-    permissions:
-      contents: read
-      packages: write
-    if: github.ref == 'refs/heads/main'
+  get-version:
     runs-on: ubuntu-24.04
-    needs:
-      - build
+    outputs:
+      version: ${{ steps.make_version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Login to ghcr
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
+      - id: make_version
+        run: echo "version=$(date --utc +%Y%m%d)-$(git rev-list ${{ github.sha }} --count)" >> "$GITHUB_OUTPUT"
+  build:
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    needs: [get-version]
+    permissions:
+      contents: read # to fetch the repository content
+      id-token: write # for signing attestation(s) with GitHub OIDC Token
+      packages: write # to push to ghcr
+    with:
+      context: ./
+      push: ${{ github.event_name != 'pull_request' }}
+      platforms: linux/amd64,linux/arm64
+      cache: true
+      cache-mode: max
+      output: image
+      meta-images: ghcr.io/svix/openapi-codegen
+      meta-flavor: |
+        latest=${{ github.event_name != 'pull_request' }}
+      meta-tags: |
+        type=raw,value=${{needs.get-version.outputs.version}}
+      set-meta-labels: true
+      labels: |
+        org.opencontainers.image.version=${{ needs.get-version.outputs.version }}
+        org.opencontainers.image.revision=${{ github.sha }}
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - run: echo "IMAGE_TAG=$(date --utc +%Y%m%d)-$(git rev-list ${{ github.sha }} --count)" >> "$GITHUB_ENV"
-
-      - name: Create manifest list and push
-        # inside the ${{ runner.temp }}/digests we downloaded empty files with the sha256 digest of the image as the filename
-        # using printf we get the digest from the filename and we add the digest to the manifest
-        # this is the recommend way of doing things :(
-        # https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
-        working-directory: ${{ runner.temp }}/digests
-        run: |
-          docker buildx imagetools create \
-            -t ${{ env.REGISTRY_IMAGE }}:latest \
-            -t ${{ env.REGISTRY_IMAGE }}:${{ env.IMAGE_TAG }} \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect "${{ env.REGISTRY_IMAGE }}:latest"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+repos:
+  - repo: builtin
+    hooks:
+      - id: end-of-file-fixer
+        exclude: "^templates/"
+      - id: trailing-whitespace
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-yaml
+        args: ["--allow-multiple-documents"]
+      - id: check-json
+        exclude: "^.vscode/"
+  - repo: https://github.com/google/yamlfmt
+    rev: 21ca5323a9c87ee37a434e0ca908efc0a89daa07 # frozen: v0.21.0
+    hooks:
+      - id: yamlfmt
+  - repo: https://github.com/rhysd/actionlint
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca # frozen: v1.7.12
+    hooks:
+      - id: actionlint
+  - repo: https://github.com/crate-ci/typos
+    rev: bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # frozen: v1.48.0
+    hooks:
+      - id: typos
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: 05c1426671b9237fb5e1444dd63aa5731bec0dfb # frozen: v3.13.1-1
+    hooks:
+      - id: shfmt
+        args: ["--write", "-i", "4", "-ci"]
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: 99470f5e12208ff0fb17ab81c3c494f7620a1d8d # frozen: v0.11.0
+    hooks:
+      - id: shellcheck
+  - repo: https://github.com/hyland/github-actions-ensure-sha-pinned-actions
+    rev: 7957efb76aba0eec7580a9c0392d3e5bec381359 # frozen: v2.0.1
+    hooks:
+      - id: gha-sha-convert
+        args: ["--allowlist", "actions/*"]
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 6b63472e72e1a91ed8a2f6d483790dfb644fa1d3 # frozen: 0.37.4
+    hooks:
+      - id: check-dependabot

--- a/.yamlfmt.yaml
+++ b/.yamlfmt.yaml
@@ -1,0 +1,6 @@
+formatter:
+  type: basic
+  retain_line_breaks_single: true
+  scan_folded_as_literal: true
+  eof_newline: true
+  drop_merge_tag: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # build openapi-codegen
-FROM docker.io/lukemathwalker/cargo-chef:latest-rust-1.88 AS chef
+FROM docker.io/rust:1.97.1-slim-trixie AS chef
+RUN cargo install --locked cargo-chef@0.1.77
+WORKDIR /app
 WORKDIR /app
 
 FROM chef AS planner
@@ -22,140 +24,153 @@ COPY src /app/src
 
 RUN cargo build --release --bin openapi-codegen
 
+FROM alpine:3.24 AS downloader
+SHELL ["/bin/sh", "-eu", "-c"]
+COPY --chown=root:root --chmod=755 download-tool.sh /usr/local/bin/download-tool.sh
+RUN --mount=target=/var/cache/apk,type=cache,sharing=locked apk add curl binutils coreutils
 
 # download rubyfmt
-FROM alpine:3.21 AS rubyfmt-downloader
-ARG RUBYFMT_DL_LINK="https://github.com/fables-tales/rubyfmt/releases/download/v0.11.67-0/rubyfmt-v0.11.67-0-Linux-x86_64.tar.gz"
-ARG RUBYFMT_SHA256="40f734a83edcc5f03f789606293af9ea622ea2a4fc3091c551b7c1f817087dcd"
-RUN apk add --no-cache curl binutils
-RUN echo "${RUBYFMT_SHA256} rubyfmt.tar.gz" > rubyfmt.tar.gz.sha256 && \
-    curl -fsSL --output rubyfmt.tar.gz "${RUBYFMT_DL_LINK}" && \
-    sha256sum rubyfmt.tar.gz.sha256 -c && \
-    tar xfv rubyfmt.tar.gz && \
-    strip tmp/releases/v0.11.67-0-Linux/rubyfmt
-
+FROM downloader AS rubyfmt-downloader
+RUN download-tool.sh rubyfmt
 
 # build csharpier
-FROM alpine:3.23 AS csharpier-builder
-ARG DOTNET_PLATFORM="linux-musl-amd64"
-WORKDIR /app
-RUN apk add --no-cache git dotnet10-sdk
+FROM downloader AS csharpier-builder
+RUN --mount=target=/var/cache/apk,type=cache,sharing=locked apk add git dotnet10-sdk
 
-RUN git clone https://github.com/belav/csharpier /app && \
-    git checkout tags/1.2.6
+RUN <<EOF
+    git clone --depth 1 --branch=1.2.6 https://github.com/belav/csharpier /app
+    cd /app || exit 1
+    case "$(uname -m)" in
+        aarch64)
+            DOTNET_PLATFORM=linux-musl-arm64
+            ;;
+        x86_64)
+            DOTNET_PLATFORM=linux-musl-amd64
+            ;;
+        *)
+            echo >&2 "unhandled platform $(uname -m)"
+            exit 1
+            ;;
+    esac
+    dotnet publish --framework net9.0 -o output \
+        -r ${DOTNET_PLATFORM} /p:StripSymbols=true \
+        /p:InvariantGlobalization=true /p:SelfContained=true \
+        /p:PublishSingleFile=true Src/CSharpier.Cli
+EOF
 
-RUN dotnet publish --framework net9.0 -o output \
-    -r ${DOTNET_PLATFORM} /p:StripSymbols=true \
-    /p:InvariantGlobalization=true /p:SelfContained=true \
-    /p:PublishSingleFile=true Src/CSharpier.Cli
 
 # build goimports
 FROM docker.io/golang:1.25-alpine AS goimports-builder
 
-RUN go install golang.org/x/tools/cmd/goimports@latest
+SHELL ["/bin/sh", "-eu", "-c"]
+RUN <<EOF
+    go install golang.org/x/tools/cmd/goimports@latest
+    go install github.com/segmentio/golines@v0.13.0
+    go install mvdan.cc/gofumpt@v0.9.1
 
-RUN go install github.com/segmentio/golines@v0.13.0
-
-RUN go install mvdan.cc/gofumpt@v0.9.1
-
-# will copy /usr/local/go into release image later, trims about 170mb
-RUN rm -rf /usr/local/go/*.md && \
-    rm -rf /usr/local/go/api && \
-    rm -rf /usr/local/go/doc && \
-    rm -rf /usr/local/go/pkg/tool/**/* && \
-    rm -rf /usr/local/go/src/* && \
+    # will copy /usr/local/go into release image later, trims about 170mb
+    rm -rf /usr/local/go/*.md
+    rm -rf /usr/local/go/api
+    rm -rf /usr/local/go/doc
+    rm -rf /usr/local/go/pkg/tool/**/*
+    rm -rf /usr/local/go/src/*
     rm -rf /usr/local/go/test/*
-
+EOF
 
 # download java formatter
-FROM alpine:3.21 AS javafmt-downloader
-ARG JAVAFMT_DL_LINK="https://repo1.maven.org/maven2/com/palantir/javaformat/palantir-java-format-native/2.75.0/palantir-java-format-native-2.75.0-nativeImage-linux-glibc_x86-64.bin"
-ARG JAVAFMT_SHA256="9d8c9e65cff44bb847d16b4db2ccbd6dacbe32611eaf2587748013eda931cdac"
-RUN apk add --no-cache curl binutils coreutils
-RUN echo "${JAVAFMT_SHA256} palantir-java-format.bin" > palantir-java-format.bin.sha256 && \
-    curl -fsSL --output palantir-java-format.bin "${JAVAFMT_DL_LINK}" && \
-    sha256sum palantir-java-format.bin.sha256 -c && \
-    mv palantir-java-format.bin /usr/bin && \
-    chmod +x /usr/bin/palantir-java-format.bin
+FROM downloader AS javafmt-downloader
+RUN download-tool.sh javafmt
 
+# Javascript
+FROM downloader AS biome-downloader
+RUN download-tool.sh biome
 
 # main image
-FROM alpine:3.21
+FROM alpine:3.24 AS main
+SHELL ["/bin/sh", "-eu", "-c"]
 ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/root/.cargo/bin"
-RUN apk add --no-cache openjdk17-jre-headless curl gcompat libgcc ruff libstdc++
+RUN --mount=target=/var/cache/apk,type=cache,sharing=locked apk add openjdk17-jre-headless curl gcompat libgcc ruff libstdc++
 
 # Kotlin
-RUN echo "5e7eb28a0b2006d1cefbc9213bfc73a8191ec2f85d639ec4fc4ec0cd04212e82 ktfmt-0.54-jar-with-dependencies.jar" > ktfmt-0.54-jar-with-dependencies.jar.sha256  && \
-    curl -fsSL --output ktfmt-0.54-jar-with-dependencies.jar "https://github.com/facebook/ktfmt/releases/download/v0.54/ktfmt-0.54-jar-with-dependencies.jar"  && \
-    sha256sum ktfmt-0.54-jar-with-dependencies.jar.sha256 -c  && \
-    rm ktfmt-0.54-jar-with-dependencies.jar.sha256  && \
-    mv ktfmt-0.54-jar-with-dependencies.jar /usr/bin/  && \
-    echo "#!/bin/sh" >> /usr/bin/ktfmt && \
-    echo '/usr/bin/java  -jar /usr/bin/ktfmt-0.54-jar-with-dependencies.jar $@' >> /usr/bin/ktfmt && \
+RUN <<EOF
+    echo "5e7eb28a0b2006d1cefbc9213bfc73a8191ec2f85d639ec4fc4ec0cd04212e82 ktfmt-0.54-jar-with-dependencies.jar" > ktfmt-0.54-jar-with-dependencies.jar.sha256
+    curl -fsSL --output ktfmt-0.54-jar-with-dependencies.jar "https://github.com/facebook/ktfmt/releases/download/v0.54/ktfmt-0.54-jar-with-dependencies.jar"
+    sha256sum ktfmt-0.54-jar-with-dependencies.jar.sha256 -c
+    rm ktfmt-0.54-jar-with-dependencies.jar.sha256
+    mv ktfmt-0.54-jar-with-dependencies.jar /usr/bin/
+    echo "#!/bin/sh" >> /usr/bin/ktfmt
+    echo 'exec /usr/bin/java  -jar /usr/bin/ktfmt-0.54-jar-with-dependencies.jar $@' >> /usr/bin/ktfmt
     chmod +x /usr/bin/ktfmt
+EOF
 
 # Java
-RUN echo "25157797a0a972c2290b5bc71530c4f7ad646458025e3484412a6e5a9b8c9aa6 google-java-format-1.25.2-all-deps.jar" > google-java-format-1.25.2-all-deps.jar.sha256 && \
-    curl -fsSL --output google-java-format-1.25.2-all-deps.jar "https://github.com/google/google-java-format/releases/download/v1.25.2/google-java-format-1.25.2-all-deps.jar" && \
-    sha256sum google-java-format-1.25.2-all-deps.jar.sha256 -c && \
-    rm google-java-format-1.25.2-all-deps.jar.sha256 && \
-    mv google-java-format-1.25.2-all-deps.jar /usr/bin/  && \
-    echo "#!/bin/sh" >> /usr/bin/google-java-format && \
-    echo '/usr/bin/java -jar /usr/bin/google-java-format-1.25.2-all-deps.jar $@' >> /usr/bin/google-java-format && \
+RUN <<EOF
+    echo "25157797a0a972c2290b5bc71530c4f7ad646458025e3484412a6e5a9b8c9aa6 google-java-format-1.25.2-all-deps.jar" > google-java-format-1.25.2-all-deps.jar.sha256
+    curl -fsSL --output google-java-format-1.25.2-all-deps.jar "https://github.com/google/google-java-format/releases/download/v1.25.2/google-java-format-1.25.2-all-deps.jar"
+    sha256sum google-java-format-1.25.2-all-deps.jar.sha256 -c
+    rm google-java-format-1.25.2-all-deps.jar.sha256
+    mv google-java-format-1.25.2-all-deps.jar /usr/bin/
+    echo "#!/bin/sh" >> /usr/bin/google-java-format
+    echo 'exec /usr/bin/java -jar /usr/bin/google-java-format-1.25.2-all-deps.jar $@' >> /usr/bin/google-java-format
     chmod +x /usr/bin/google-java-format
+EOF
 
 
 # Javascript
-ARG BIOME_DL_LINK="https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%402.1.4/biome-linux-x64-musl"
-ARG BIOME_SHA256="6d6bd2213cffab0d68d741c0be466bcd21cd6f5eca1e0e5aac2a991bf9f17cf2"
-RUN echo "${BIOME_SHA256} biome" > biome.sha256 && \
-    curl -fsSL --output biome "${BIOME_DL_LINK}" && \
-    sha256sum biome.sha256 -c && \
-    rm biome.sha256 && \
-    mv biome /usr/bin/  && \
-    chmod +x /usr/bin/biome
+COPY --chown=root:root --chmod=755 --from=biome-downloader /usr/bin/biome /usr/bin/biome
 
 # Ruby
-COPY --from=rubyfmt-downloader /tmp/releases/v0.11.67-0-Linux/rubyfmt /usr/bin/rubyfmt
+COPY --chown=root:root --chmod=755 --from=rubyfmt-downloader /tmp/rubyfmt /usr/bin/rubyfmt
 
 # Go
 COPY --from=goimports-builder /usr/local/go/ /usr/local/go/
-COPY --from=goimports-builder /go/bin/goimports /usr/bin
-COPY --from=goimports-builder /go/bin/golines /usr/bin
-COPY --from=goimports-builder /go/bin/gofumpt /usr/bin
+COPY --chown=root:root --chmod=755 --from=goimports-builder /go/bin/goimports /usr/bin
+COPY --chown=root:root --chmod=755 --from=goimports-builder /go/bin/golines /usr/bin
+COPY --chown=root:root --chmod=755 --from=goimports-builder /go/bin/gofumpt /usr/bin
 
 # C#
-COPY --from=csharpier-builder /app/output/CSharpier /usr/bin/csharpier
+COPY --chown=root:root --chmod=755 --from=csharpier-builder /app/output/CSharpier /usr/bin/csharpier
 
 # Rust
 # All of this craziness reduces the image size by about 600Mb
-RUN apk add --no-cache binutils && \
+RUN --mount=target=/var/cache/apk,type=cache,sharing=locked <<EOF
+    apk add binutils
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
     -y \
     --profile minimal \
     --no-modify-path \
     --no-update-default-toolchain \
     --default-toolchain nightly-2025-02-27 \
-    --component rustfmt && \
-    rm -rf /root/.rustup/toolchains/nightly-*/lib/rustlib && \
-    rm /root/.rustup/toolchains/nightly-*/bin/cargo* && \
-    rm /root/.rustup/toolchains/nightly-*/bin/rust-* && \
-    rm /root/.rustup/toolchains/nightly-*/bin/rustc && \
-    rm /root/.rustup/toolchains/nightly-*/bin/rustdoc && \
-    rm -rf /root/.rustup/toolchains/nightly-*/share && \
-    strip /root/.rustup/toolchains/nightly-*/lib/librustc_driver-*.so && \
+    --component rustfmt
+    rm -rf /root/.rustup/toolchains/nightly-*/lib/rustlib
+    rm /root/.rustup/toolchains/nightly-*/bin/cargo*
+    rm /root/.rustup/toolchains/nightly-*/bin/rust-*
+    rm /root/.rustup/toolchains/nightly-*/bin/rustc
+    rm /root/.rustup/toolchains/nightly-*/bin/rustdoc
+    rm -rf /root/.rustup/toolchains/nightly-*/share
+    strip /root/.rustup/toolchains/nightly-*/lib/librustc_driver-*.so
     apk del binutils
+EOF
 
 # PHP
-RUN apk add --no-cache php84-tokenizer php84-phar php84-iconv php84-mbstring php84 && \
-    echo "0a9ad9fd8996064ff9aabfba3cb1cea148e3a1785263f6f91ff1431def402513  php-cs-fixer.phar" >  php-cs-fixer.phar.sha256  && \
-    curl -fsSL --output php-cs-fixer.phar https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/v3.86.0/php-cs-fixer.phar && \
-    sha256sum -c php-cs-fixer.phar.sha256 && \
-    rm php-cs-fixer.phar.sha256 && \
+RUN --mount=target=/var/cache/apk,type=cache,sharing=locked apk add php84-tokenizer php84-phar php84-iconv php84-mbstring php84
+RUN <<EOF
+    echo "0a9ad9fd8996064ff9aabfba3cb1cea148e3a1785263f6f91ff1431def402513  php-cs-fixer.phar" >  php-cs-fixer.phar.sha256
+    curl -fsSL --output php-cs-fixer.phar https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/v3.86.0/php-cs-fixer.phar
+    sha256sum -c php-cs-fixer.phar.sha256
+    rm php-cs-fixer.phar.sha256
     mv php-cs-fixer.phar /usr/share
+EOF
 
 # Java formatter for code samples
 COPY --from=javafmt-downloader /usr/bin/palantir-java-format.bin /usr/bin/palantir-java-format.bin
 
 # openapi-codegen
 COPY --from=openapi-codegen-builder /app/target/release/openapi-codegen /usr/bin/
+
+LABEL org.opencontainers.image.authors="support@svix.com" \
+      org.opencontainers.image.description="Svix's OpenAPI code generation" \
+      org.opencontainers.image.title="openapi-codegen" \
+      org.opencontainers.image.vendor="Svix" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.base.name="docker.io/alpine:3.24"

--- a/Dockerfile
+++ b/Dockerfile
@@ -163,10 +163,10 @@ RUN <<EOF
 EOF
 
 # Java formatter for code samples
-COPY --from=javafmt-downloader /usr/bin/palantir-java-format.bin /usr/bin/palantir-java-format.bin
+COPY --chown=root:root --chmod=755 --from=javafmt-downloader /usr/bin/palantir-java-format.bin /usr/bin/palantir-java-format.bin
 
 # openapi-codegen
-COPY --from=openapi-codegen-builder /app/target/release/openapi-codegen /usr/bin/
+COPY --chown=root:root --chmod=755 --from=openapi-codegen-builder /app/target/release/openapi-codegen /usr/bin/
 
 LABEL org.opencontainers.image.authors="support@svix.com" \
       org.opencontainers.image.description="Svix's OpenAPI code generation" \

--- a/download-tool.sh
+++ b/download-tool.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+set -eu
+
+ARCH="$(uname -m)"
+
+case "$ARCH" in
+    aarch64)
+        BIOME_DL_LINK=https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%402.1.4/biome-linux-arm64-musl
+        BIOME_SHA256=ffa05ea6ec0e73072e46301a692eb9413d5b683366e86ab7243414ae944f4ec4
+        RUBYFMT_DL_LINK=https://github.com/fables-tales/rubyfmt/releases/download/v0.11.67-0/rubyfmt-v0.11.67-0-Linux-aarch64.tar.gz
+        RUBYFMT_SHA256=805fec1bf5400513058d8ec2d5cde0b497182b80828957ef0239190aa1f01092
+        JAVAFMT_DL_LINK=https://repo1.maven.org/maven2/com/palantir/javaformat/palantir-java-format-native/2.75.0/palantir-java-format-native-2.75.0-nativeImage-linux-glibc_aarch64.bin
+        JAVAFMT_SHA256=371e226632a5c455f017fe2ce2a614abe8cf81c743b4c27fb998373b790c2a3b
+        ;;
+    x86_64)
+        BIOME_DL_LINK=https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%402.1.4/biome-linux-x64-musl
+        BIOME_SHA256=6d6bd2213cffab0d68d741c0be466bcd21cd6f5eca1e0e5aac2a991bf9f17cf2
+        RUBYFMT_DL_LINK=https://github.com/fables-tales/rubyfmt/releases/download/v0.11.67-0/rubyfmt-v0.11.67-0-Linux-x86_64.tar.gz
+        RUBYFMT_SHA256=40f734a83edcc5f03f789606293af9ea622ea2a4fc3091c551b7c1f817087dcd
+        JAVAFMT_DL_LINK=https://repo1.maven.org/maven2/com/palantir/javaformat/palantir-java-format-native/2.75.0/palantir-java-format-native-2.75.0-nativeImage-linux-glibc_x86-64.bin
+        JAVAFMT_SHA256=9d8c9e65cff44bb847d16b4db2ccbd6dacbe32611eaf2587748013eda931cdac
+        ;;
+    *)
+        echo >&2 "Error: Unhandled architecture $ARCH"
+        exit 1
+        ;;
+esac
+
+TOOL="${1:-}"
+
+WD=$(mktemp -d)
+
+on_exit() {
+    status=$?
+    cd /
+    rm -rf "$WD"
+    exit $status
+}
+
+trap on_exit EXIT INT TERM
+
+cd "$WD" || exit 1
+
+case "$TOOL" in
+    "")
+        echo >&2 "Usage: $0 (biome|rubyfmt|javafmt)"
+        exit 2
+        ;;
+    rubyfmt)
+        echo "${RUBYFMT_SHA256} rubyfmt.tar.gz" >rubyfmt.tar.gz.sha256
+        curl -fsSL --output rubyfmt.tar.gz "${RUBYFMT_DL_LINK}"
+        sha256sum rubyfmt.tar.gz.sha256 -c
+        tar xfv rubyfmt.tar.gz
+        strip tmp/releases/v0.11.67-0-Linux/rubyfmt
+        mv tmp/releases/v0.11.67-0-Linux/rubyfmt /tmp/rubyfmt
+        ;;
+    javafmt)
+        echo "${JAVAFMT_SHA256} palantir-java-format.bin" >palantir-java-format.bin.sha256
+        curl -fsSL --output palantir-java-format.bin "${JAVAFMT_DL_LINK}"
+        sha256sum palantir-java-format.bin.sha256 -c
+        mv palantir-java-format.bin /usr/bin
+        chmod +x /usr/bin/palantir-java-format.bin
+        ;;
+    biome)
+        echo "${BIOME_SHA256} biome" >biome.sha256
+        curl -fsSL --output biome "${BIOME_DL_LINK}"
+        sha256sum biome.sha256 -c
+        rm biome.sha256
+        mv biome /usr/bin/
+        chmod +x /usr/bin/biome
+        ;;
+    *)
+        echo >&2 "Unrecognized tool $TOOL"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Many changes:

 - Add `prek` / `pre-commit` rules
 - Pin github actions by SHA
 - Use docker/github-builder instead of doing it by hand
 - Move all of the platform-specific logic into the Dockerfile instead of the Github Actions so you can just do `docker build` on any platform and it works
 - Bump to alpine 3.24 from 3.21
 - Add dependabot
 - Run the full build in CI (but don't push it!)